### PR TITLE
stream_file: enable cache for fstype "fuse.sshfs"

### DIFF
--- a/stream/stream_file.c
+++ b/stream/stream_file.c
@@ -193,7 +193,7 @@ static bool check_stream_network(int fd)
 {
     struct statfs fs;
     const char *stypes[] = { "afpfs", "nfs", "smbfs", "webdav", "osxfusefs",
-                             "fuse", "fusefs.sshfs", NULL };
+                             "fuse", "fuse.sshfs", "fusefs.sshfs", NULL };
     if (fstatfs(fd, &fs) == 0)
         for (int i=0; stypes[i]; i++)
             if (strcmp(stypes[i], fs.f_fstypename) == 0)


### PR DESCRIPTION
I noticed mpv was lagging while playing over sshfs, and found that the sshfs type name "fuse.sshfs" was not recognised in mpv.

Distro: NixOS 19.09

```
$ mount | grep sshfs
foo.example.com:/mnt/foo on /home/linus/foo type fuse.sshfs (rw,nosuid,nodev,relatime,user_id=1000,group_id=100)

$ sshfs --version
SSHFS version 3.5.2
FUSE library version 3.6.2
using FUSE kernel interface version 7.29
fusermount3 version: 3.6.2

$ uname -a
Linux bar.example.com 4.19.114 #1-NixOS SMP Thu Apr 2 13:28:25 UTC 2020 x86_64 GNU/Linux
```

I agree that my changes can be relicensed to LGPL 2.1 or later.